### PR TITLE
[mod] posts一覧を、共通パーツに移動

### DIFF
--- a/app/views/layouts/_post.erb
+++ b/app/views/layouts/_post.erb
@@ -1,3 +1,4 @@
+<%# TODO: TailwindCSSを細かく修正 %>
 <% @posts.each do |post| %>
   <%= link_to post_path(post.id) do %>
     <div class="w-full h-full mx-auto">

--- a/app/views/layouts/_post.erb
+++ b/app/views/layouts/_post.erb
@@ -1,0 +1,36 @@
+<% @posts.each do |post| %>
+  <%= link_to post_path(post.id) do %>
+    <div class="w-full h-full mx-auto">
+      <div class="flex max-w-sm w-80 bg-white shadow-md rounded-lg overflow-hidden mx-auto">
+        <div class='flex items-center w-full px-2 py-3'>
+          <div class='mx-3 w-full'>
+            <div class="flex flex-row mb-4">
+              <div class='text-gray-600 font-semibold'><%= post.title %></div>
+            </div>
+            <div class='text-gray-400 font-medium text-sm border-2 border-gray-300 rounded-md cursor-pointer mb-5'>
+              <img class="rounded" src="https://picsum.photos/536/354">
+              <div class='text-gray-600 font-semibold'>タイトル</div>
+            </div>
+            <div class="flex justify-start mb-2">
+              <div class="flex w-full justify-end mt-1">
+                <div class='font-medium text-xs mr-5'>
+                  <span class="bg-gray-200 px-2 py-1 text-center rounded text-gray-400 cursor-pointer">
+                    <%= post.tag_id %>
+                  </span>
+                </div>
+                <div class='font-medium text-xs mr-5'>
+                  <span class="bg-gray-200 px-2 py-1 text-center rounded text-gray-400 cursor-pointer">
+                    <i class="fas fa-heart"></i> 1
+                  </span>
+                </div>
+              </div>
+              <div class='text-gray-400 font-medium text-sm border-2 rounded-full border-pink-600 cursor-pointer'>
+                <img class="h-6 w-6 rounded-full" src="app/assets/images/ogp_1200x630.png">
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,14 +1,4 @@
-<h1>Posts#index</h1>
-<p>Find me in app/views/posts/index.html.erb</p>
-
-<% @posts.each do |post| %>
-  <p>title : <%= link_to post.title, post_path(post.id) %></p>
-  <p>URL : <%= Rinku.auto_link(post.url, :all, 'target="_blank"').html_safe %></p>
-  <p>tag_id : <%= post.tag_id %></p>
-  <p>日付 : <%= post.created_at %></p>
-  <p>投稿者 : <%= post.user_id %></p>
-  <hr>
-<% end %>
+<%= render "layouts/post" %>
 
 <p><%= link_to "新規作成", new_post_path %></p>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,11 +4,4 @@
 <p>name : <%= @user.name %></p>
 <hr>
 
-<% @posts.each do |post| %>
-  <p>title : <%= link_to post.title, post_path(post.id) %></p>
-  <p>URL : <%= Rinku.auto_link(post.url, :all, 'target="_blank"').html_safe %></p>
-  <p>tag_id : <%= post.tag_id %></p>
-  <p>日付 : <%= post.created_at %></p>
-  <p>投稿者 : <%= post.user_id %></p>
-  <hr>
-<% end %>
+<%= render "layouts/post" %>


### PR DESCRIPTION
## 変更の概要

- posts一覧表示をするページで、postを共通パーツで作成し、それを各ページで呼び出す。

## なぜこの変更をするのか

- pots/indexやusers/showなどposts一覧表示するページが複数あるため。

## やったこと、なぜやったのか

- layouts/_post.erbにpost一覧表示のパーツを作成した。

## やらないこと

- CSSの細かな設定
## 影響範囲

なし
