### PR TITLE
いいね一覧で表示されるpostsがおかしかったので修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def likes
-    @posts = Post.joins(:likes).where(user_id: current_user.id).page(params[:page]).per(9)
+    @posts = Post.includes(:likes).where(likes: {user_id: current_user.id}).page(params[:page]).per(9)
   end
 
   def show


### PR DESCRIPTION
## 変更の概要
いいね一覧で表示されるpostsがおかしかったので修正
* 変更の概要
* 関連するIssueやプルリクエスト

## なぜこの変更をするのか
いいね一覧で表示されるpostsがおかしかったから
* 変更をする理由
* 前提知識がなくても分かるようにする

## やったこと、なぜやったのか
・user_idがいいねしたユーザという意味なのに、usersとlikesどちらにも存在していたため一覧がおかしくなった。そのため、likesのuser_idに指定
・joinからincludesに変更
* このプルリクで何をしたのか？

## やらないこと

* このプルリクでやらないことは何か？（やらない場合は、いつやるのかを明記する。）

## 影響範囲
自分がいいねした記事が表示
* ユーザーへの影響？

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
